### PR TITLE
feat: add apps that can't be installed as Flatpaks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,12 +56,15 @@ dnf -y install \
    "gnome-bluetooth" \
    "gnome-color-manager" \
    "gnome-control-center" \
+   "gnome-disk-utility" \
    "gnome-initial-setup" \
    "gnome-remote-desktop" \
    "gnome-session-wayland-session" \
    "gnome-settings-daemon" \
    "gnome-shell" \
    "gnome-software" \
+   "gnome-system-monitor" \
+   "gnome-tweaks" \
    "gnome-user-docs" \
    "gvfs-fuse" \
    "gvfs-goa" \


### PR DESCRIPTION
Some users may need to use Tweaks, System Monitor, or Disks, and is impossible without using rpm-ostree or making a new derived image.